### PR TITLE
Set server request uri to root in CliTaskCommand.php.

### DIFF
--- a/src/BeyondIT/OCOK/CliTaskCommand.php
+++ b/src/BeyondIT/OCOK/CliTaskCommand.php
@@ -8,11 +8,11 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
 class CliTaskCommand extends OCOKCommand {
-    
+
     public function supportedVersions() {
         return array('2','1.5');
     }
-    
+
     protected function configure() {
         $this->setName("run")
              ->setDescription("Run OpenCart controllers as tasks from commandline")
@@ -21,14 +21,14 @@ class CliTaskCommand extends OCOKCommand {
              ->addArgument("route", InputArgument::REQUIRED, "Set the route for the Task Controller")
              ->addArgument("args", InputArgument::IS_ARRAY, "Custom arguments, which are set as GET or POST (-p option) parameters for the controller script. Added as key/value pairs (e.g. key=value)");
     }
-    
+
     protected function execute(InputInterface $input, OutputInterface $output) {
         if (parent::execute($input, $output)) {
-                            
+
             if (!$input->getOption("catalog")) {
-                chdir('admin');  
+                chdir('admin');
             }
-                                    
+
             foreach ($input->getArgument("args") as $arg) {
                 $pair = explode("=", $arg);
                 if (count($pair) === 2) {
@@ -36,9 +36,11 @@ class CliTaskCommand extends OCOKCommand {
                         $_POST[$pair[0]] = $pair[1];
                     } else {
                         $_GET[$pair[0]] = $pair[1];
-                    }                    
+                    }
                 }
             }
+
+            $_SERVER['REQUEST_URI'] = '/';
 
             ob_start();
             require_once $this->getOCDirectory() . DIRECTORY_SEPARATOR . "index.php";
@@ -52,5 +54,5 @@ class CliTaskCommand extends OCOKCommand {
 
 
         }
-    }    
+    }
 }


### PR DESCRIPTION
To prevent redirect when running task on store with `VQMod` and `SeoPro` used in.

When OpenCart uses `VQMod` with `SeoPro`, there is impossible to run controller-based task because redirect happens while `            require_once $this->getOCDirectory() . DIRECTORY_SEPARATOR . "index.php";` evaluated (in `OCOK/CliTaskCommand.php`).

This happens because `vqmod/vqcache/vq2-system_startup.php:64`:
```
if (!isset($_SERVER['REQUEST_URI'])) {
	$_SERVER['REQUEST_URI'] = substr($_SERVER['PHP_SELF'], 1);

	if (isset($_SERVER['QUERY_STRING'])) {
		$_SERVER['REQUEST_URI'] .= '?' . $_SERVER['QUERY_STRING'];
	}
}
```
After evaluating code above $_SERVER['REQUEST_URI'] is `cok.phar`. Then in `catalog/controller/common/seo_pro.php` in `validate()` method redirect happens because $url ends with `/cok.phar` while $seo ends with only `/`:297:
```
		if (isset($this->request->server['HTTPS']) && (($this->request->server['HTTPS'] == 'on') || ($this->request->server['HTTPS'] == '1'))) {
			$config_ssl = substr($this->config->get('config_ssl'), 0, $this->strpos_offset('/', $this->config->get('config_ssl'), 3) + 1);
			$url = str_replace('&amp;', '&', $config_ssl . ltrim($this->request->server['REQUEST_URI'], '/'));
			$seo = str_replace('&amp;', '&', $this->url->link($this->request->get['route'], $this->getQueryString(array('route')), 'SSL'));
		} else {
			$config_url = substr($this->config->get('config_url'), 0, $this->strpos_offset('/', $this->config->get('config_url'), 3) + 1);
			$url = str_replace('&amp;', '&', $config_url . ltrim($this->request->server['REQUEST_URI'], '/'));
			$seo = str_replace('&amp;', '&', $this->url->link($this->request->get['route'], $this->getQueryString(array('route')), 'NONSSL'));
		}

		if (rawurldecode($url) != rawurldecode($seo)) {
			header($this->request->server['SERVER_PROTOCOL'] . ' 301 Moved Permanently');

			$this->response->redirect($seo);
		}
```
